### PR TITLE
Change opacity and color if backdrop-filter not supported for dialog

### DIFF
--- a/theme/custom/themes.scss
+++ b/theme/custom/themes.scss
@@ -30,7 +30,7 @@ $themesConfig: (
 $colorOpacities:(
   primary: 10 20 25 30 40 50 60 70 80,
   hero: 10 20 30 60,
-  upper: 40
+  upper: 40 90,
 );
 
 /**

--- a/theme/src/dialog.scss
+++ b/theme/src/dialog.scss
@@ -31,14 +31,15 @@
     margin: 0;
 
     &:not(.secondary) .el-dialog {
-      /* support backdrop-filter */
-      @supports ( (-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px)) ) {
-        -webkit-backdrop-filter: blur(8px);
-        backdrop-filter: blur(8px);
-      }
       @include themify {
         color: themed('color_primary');
-        background-color: themed('color_primary_20');
+        background-color: themed('color_upper_90');
+
+        @supports ((-webkit-backdrop-filter: blur(8px))) or (backdrop-filter: blur(8px)) {
+          -webkit-backdrop-filter: blur(8px);
+          backdrop-filter: blur(8px);
+          background-color: themed('color_primary_20');
+        }
       }
     }
 


### PR DESCRIPTION
Issue on IE11:
<img width="469" alt="Screen Shot 2019-12-18 at 1 11 44 PM" src="https://user-images.githubusercontent.com/9317101/71115787-62874800-2198-11ea-8f38-56d8cd6ab73a.png">

Results:
<img width="451" alt="Screen Shot 2019-12-18 at 1 10 55 PM" src="https://user-images.githubusercontent.com/9317101/71115823-77fc7200-2198-11ea-8d5b-bac2c8f14997.png">
<img width="441" alt="Screen Shot 2019-12-18 at 1 11 16 PM" src="https://user-images.githubusercontent.com/9317101/71115827-79c63580-2198-11ea-8964-0c2ea40775f0.png">

